### PR TITLE
Added sleep to message store retry loop

### DIFF
--- a/mongodb_store/src/mongodb_store/message_store.py
+++ b/mongodb_store/src/mongodb_store/message_store.py
@@ -56,6 +56,7 @@ class MessageStoreProxy:
                                 found_services_first_try = False
                                 rospy.logerr("Could not get message store services. Maybe the message "
                                              "store has not been started? Retrying..")
+                                rospy.sleep(0.5)
                 if not found_services_first_try:
                         rospy.loginfo("Message store services found.")
 		self.insert_srv = rospy.ServiceProxy(insert_service, dc_srv.MongoInsertMsg)


### PR DESCRIPTION
Without the sleep the loop runs at maximum speed and produces many error messages.
Today we had 15 GB filled with this single error message.
